### PR TITLE
Add new draft_pull_request_enabled to the TriggerMapItemModel defintion

### DIFF
--- a/bitrise.schema.json
+++ b/bitrise.schema.json
@@ -375,6 +375,9 @@
         "pull_request_target_branch": {
           "type": "string"
         },
+        "draft_pull_request_enabled": {
+          "type": "boolean"
+        },
         "tag": {
           "type": "string"
         },

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,5 +12,5 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -xeo pipefail
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
             golangci-lint run


### PR DESCRIPTION
This PR adds the `draft_pull_request_enabled` property to the `TriggerMapItemModel` definition, to support draft PR trigger control.

To test this change locally configure a schema mapping for `bitrise.yml` files with the new schema's remote URL: `https://raw.githubusercontent.com/bitrise-io/bitrise-json-schemas/draft-pull-request/bitrise.schema.json`

![Screenshot 2024-01-17 at 09 34 35](https://github.com/bitrise-io/bitrise-json-schemas/assets/12427060/48bb4916-4814-40e7-b422-2aac2561721c)
