### PR TITLE
Add no_output_timeout to bitrise.yml schema's step schema

### DIFF
--- a/bitrise.schema.json
+++ b/bitrise.schema.json
@@ -306,6 +306,9 @@
         "timeout": {
           "type": "integer"
         },
+        "no_output_timeout": {
+          "type": "integer"
+        },
         "meta": {
           "patternProperties": {
             ".*": {


### PR DESCRIPTION
This PR adds the missing [no_output_timeout](https://github.com/bitrise-io/stepman/blob/master/models/models.go#L112) property to the bitrise.yml schema's step schema.