### PR TITLE
Fix schema json

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2,6 +2,12 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+meta:
+  bitrise.io:
+    stack: ubuntu-noble-24.04-bitrise-2025-android
+    machine_type_id: standard
+
+
 workflows:
   test:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,18 +7,12 @@ meta:
     stack: ubuntu-noble-24.04-bitrise-2025-android
     machine_type_id: standard
 
+
 workflows:
   test:
     steps:
     - go-list: {}
     - go-test: {}
-    - script@1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -xeo pipefail
-            jq empty step.schema.json
-        title: Validate schema json
     - script:
         title: Run golangci-lint
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,12 +7,18 @@ meta:
     stack: ubuntu-noble-24.04-bitrise-2025-android
     machine_type_id: standard
 
-
 workflows:
   test:
     steps:
     - go-list: {}
     - go-test: {}
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -xeo pipefail
+            jq empty step.schema.json
+        title: Validate schema json
     - script:
         title: Run golangci-lint
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2,12 +2,6 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-meta:
-  bitrise.io:
-    stack: ubuntu-noble-24.04-bitrise-2025-android
-    machine_type_id: standard
-
-
 workflows:
   test:
     steps:

--- a/schemas_test.go
+++ b/schemas_test.go
@@ -194,7 +194,7 @@ type_tags:
 - utility
 - invalid
 `,
-		wantErr: `I[#/type_tags/1] S[#/properties/type_tags/items/enum] value must be one of "access-control", "artifact-info", "build", "code-sign", "dependency", "deploy", "installer", "notification", "security", "test", "utility",`,
+		wantErr: `I[#/type_tags/1] S[#/properties/type_tags/items/enum] value must be one of "access-control", "artifact-info", "build", "code-sign", "dependency", "deploy", "installer", "notification", "security", "test", "utility"`,
 	},
 	{
 		name: "is always run is set if notification type tag",

--- a/step.schema.json
+++ b/step.schema.json
@@ -103,9 +103,9 @@
           "deploy",
           "installer",
           "notification",
-          "utility",
           "security",
-          "test"
+          "test",
+          "utility"
         ]
       }
     },

--- a/step.schema.json
+++ b/step.schema.json
@@ -102,7 +102,7 @@
           "dependency",
           "deploy",
           "installer",
-          "notification"
+          "notification",
           "utility",
           "security",
           "test"


### PR DESCRIPTION
Adds a missing comma.

The CI trigger is broken because the CI targets an out-of-date stack (and is defined in bitrise.io, not git).

Once I get access to the project, my next PR will fix the CI and add `jq empty step.schema.json` to the workflow (if not already present) to avoid this in the future. Will also define a branch protection rule to prevent merging without CI.