### PR TITLE
Re-enable CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,7 +21,7 @@ workflows:
             #!/bin/env bash
             set -xeo pipefail
             curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
-            golangci-lint run
+            $(go env GOPATH)/bin/golangci-lint run
 meta:
   bitrise.io:
     machine_type_id: standard

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -20,7 +20,7 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -xeo pipefail
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+            curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
             $(go env GOPATH)/bin/golangci-lint run
 meta:
   bitrise.io:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -20,7 +20,7 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -xeo pipefail
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
             $(go env GOPATH)/bin/golangci-lint run
 meta:
   bitrise.io:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,10 +1,17 @@
 # yaml-language-server: $schema=./bitrise.schema.json
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-
+project_type: other
+trigger_map:
+- push_branch: "*"
+  workflow: test
+- pull_request_source_branch: "*"
+  workflow: test
 workflows:
   test:
     steps:
+    - activate-ssh-key@4: {}
+    - git-clone@6: {}
     - go-list: {}
     - go-test: {}
     - script:
@@ -15,3 +22,7 @@ workflows:
             set -xeo pipefail
             curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
             golangci-lint run
+meta:
+  bitrise.io:
+    machine_type_id: standard
+    stack: ubuntu-noble-24.04-bitrise-2025-android

--- a/schemas_test.go
+++ b/schemas_test.go
@@ -222,7 +222,7 @@ project_type_tags:
 - ios
 - unsupported
 `,
-		wantErr: `I[#/project_type_tags/1] S[#/properties/project_type_tags/items/enum] value must be one of "ios", "macos", "android", "xamarin", "react-native", "cordova", "ionic", "flutter"`,
+		wantErr: `I[#/project_type_tags/1] S[#/properties/project_type_tags/items/enum] value must be one of "ios", "macos", "android", "react-native", "cordova", "ionic", "flutter", "kotlin-multiplatform", "node-js", "java", "web", "other"`,
 	},
 	{
 		name: "timtout > 0",


### PR DESCRIPTION
CI was not running on this project. The first culprit was targeting a deprecated stack (Xcode 13). It was hard to fix because I didn't have access to the CI project. The CI project controlled the trigger, and then used a script with `bitrise run` to do the actual checks.

I've moved all trigger and stack selection logic into the bitrise.yml and updated the Bitrise project to use yml in repo.

This PR also includes a couple of other fixes:
* `golangci-lint` install was broken and used an older version which failed validation
* One test needed updating with the new project types.